### PR TITLE
Add an option to not display forked repos (default on)

### DIFF
--- a/gh.js
+++ b/gh.js
@@ -1,3 +1,4 @@
+(function() {
 "use strict";
 function rateMessage(){
     console.log("rate limit fail");
@@ -6,7 +7,7 @@ function rateMessage(){
     document.getElementById("instructions").style.display = 'block';
     var message = "It looks like you've exceeded the GitHub API's rate"+
     "limit, which is 60 requests per hour. Try again later, or from a "+
-    "different IP address.";
+    'different IP address. Alternately, enter a token (as found <a href="https://github.com/settings/tokens">here</a>"';
     document.getElementById("instructions").innerHTML = message;
 }
 // yay https://developer.github.com/v3/#cross-origin-resource-sharing
@@ -18,15 +19,23 @@ function handleRepoList() {
         if (data.message.match(/Not Found/)){
             alert("Invalid user. Please try with a valid GitHub username.");
         }
-        if (data.message.match(/API rate limit/i)){
+        else if (data.message.match(/API rate limit/i)){
             rateMessage();
         }
+        else {
+            // make sure an unknown error doesn't get lost in the aether
+            var row = document.createElement("li");
+            row.appendChild(document.createTextNode(data.message));
+            document.getElementById("messages").appendChild(row);
+        }
+        // TODO, handle 'Bad credentials' more gracefully
     }
     else{
         data.forEach(learnAboutRepo);
     }
 }
 function learnAboutRepo(repoObj){
+    var token = document.getElementById("ghtoken").value;
     var name = repoObj.name;
     console.log(name);
     var url = repoObj.url + '/contents';
@@ -36,6 +45,9 @@ function learnAboutRepo(repoObj){
     //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
     repoReq.onload = digInFiles.bind(repoReq, name, html_url);
     repoReq.open("get", url, true);
+    if(token.length > 0) {
+        repoReq.setRequestHeader("Authorization", "token " + token);
+    }
     repoReq.send();
 }
 
@@ -43,14 +55,15 @@ function digInFiles(name, link){
     console.log(name);
     var repo = JSON.parse(this.responseText);
     var licensefound = false;
-    var readmefound = false; 
+    var readmefound = false;
     repo.forEach(function(repo){
         licensefound = !!(licensefound || repo.name.match(/license/i) || repo.name.match(/copying/i));
-        readmefound = !!(readmefound || repo.name.match(/readme/i))
+        readmefound = !!(readmefound || repo.name.match(/readme/i));
     });
     console.log(repo);
     var append = "";
     if (repo.message){
+        // If we got back a message, that means we hit an error of some kind. Add it to the 'messages' thingy just so the user sees *something*
         if (repo.message.match(/API rate limit/i)){
             rateMessage();
         }
@@ -60,7 +73,7 @@ function digInFiles(name, link){
         }
     }
     else{
-        // try to do analytics with gaq 
+        // try to do analytics with gaq
         var _gaq = _gaq || [];
         append = "<li>"+"<a href=\""+link+"\">"+name+"</a></li>";
         if (licensefound){
@@ -88,6 +101,7 @@ function getUser(){
     document.getElementById("haslicense").innerHTML = "";
     document.getElementById("lackslicense").innerHTML = "";
     var user = document.getElementById('ghuser').value;
+    var token = document.getElementById("ghtoken").value;
 
     // be stalkey, because why not
     var _gaq = _gaq || [];
@@ -98,6 +112,9 @@ function getUser(){
     oReq.onload = handleRepoList;
     var url = "https://api.github.com/users/" + user + "/repos";
     oReq.open("get", url, true);
+    if(token.length > 0) {
+        oReq.setRequestHeader("Authorization", "token " + token);
+    }
     oReq.send();
     console.log("username " + user);
     //make output visible and hide intsructions
@@ -110,3 +127,5 @@ document.querySelector('#ghform').addEventListener('submit', function(ev){
     getUser();
     return false;
 });
+
+})();

--- a/gh.js
+++ b/gh.js
@@ -40,10 +40,11 @@ function learnAboutRepo(repoObj){
     console.log(name);
     var url = repoObj.url + '/contents';
     var html_url = repoObj.html_url;
+    var isfork = repoObj.fork;
     console.log(url);
     var repoReq = new XMLHttpRequest();
     //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
-    repoReq.onload = digInFiles.bind(repoReq, name, html_url);
+    repoReq.onload = digInFiles.bind(repoReq, name, isfork, html_url);
     repoReq.open("get", url, true);
     if(token.length > 0) {
         repoReq.setRequestHeader("Authorization", "token " + token);
@@ -51,7 +52,7 @@ function learnAboutRepo(repoObj){
     repoReq.send();
 }
 
-function digInFiles(name, link){
+function digInFiles(name, isfork, link){
     console.log(name);
     var repo = JSON.parse(this.responseText);
     var licensefound = false;
@@ -61,36 +62,60 @@ function digInFiles(name, link){
         readmefound = !!(readmefound || repo.name.match(/readme/i));
     });
     console.log(repo);
-    var append = "";
+
+    // Wrap row creation in a function so that we get two different elements; can't append the same element twice
+    // cloneNode(deep) isn't supported on some old browsers I think, so avoid that
+    var createRow = function() {
+      var row = document.createElement("li");
+      var rowLink = document.createElement("a");
+      rowLink.href = link;
+      rowLink.appendChild(document.createTextNode(name));
+      row.appendChild(rowLink);
+
+      if (isfork) {
+        var isForkNode = document.createElement("i");
+        isForkNode.appendChild(document.createTextNode("(fork)"));
+        row.appendChild(isForkNode);
+
+        var forksHidden = document.querySelector("#hideforks").checked;
+        row.classList.add('fork');
+        if(forksHidden) {
+          row.classList.add('hide-fork');
+        }
+      }
+      return row;
+    };
+
     if (repo.message){
         // If we got back a message, that means we hit an error of some kind. Add it to the 'messages' thingy just so the user sees *something*
         if (repo.message.match(/API rate limit/i)){
             rateMessage();
         }
         else{
-            append = "<li>"+"<a href=\""+link+"\">"+name+"</a>"+repo.message+"</li>";
-            document.getElementById("messages").innerHTML += append;
+            var row = createRow();
+            row.appendChild(document.createTextNode(repo.message));
+            document.getElementById("messages").appendChild(row);
         }
     }
     else{
         // try to do analytics with gaq
         var _gaq = _gaq || [];
-        append = "<li>"+"<a href=\""+link+"\">"+name+"</a></li>";
+
         if (licensefound){
-            _gaq.push(['users._trackEvent', 'licenseFound', link])
-            document.getElementById("haslicense").innerHTML += append;
+            _gaq.push(['users._trackEvent', 'licenseFound', link]);
+            document.getElementById("haslicense").appendChild(createRow());
         }
         else{
-            _gaq.push(['users._trackEvent', 'licenseMissing', link])
-            document.getElementById("lackslicense").innerHTML += append;
+            _gaq.push(['users._trackEvent', 'licenseMissing', link]);
+            document.getElementById("lackslicense").appendChild(createRow());
         }
         if (readmefound){
-            _gaq.push(['users._trackEvent', 'readmeFound', link])
-            document.getElementById("hasreadme").innerHTML += append;
+            _gaq.push(['users._trackEvent', 'readmeFound', link]);
+            document.getElementById("hasreadme").appendChild(createRow());
         }
         else{
-            _gaq.push(['users._trackEvent', 'readmeMissing', link])
-            document.getElementById("lacksreadme").innerHTML += append;
+            _gaq.push(['users._trackEvent', 'readmeMissing', link]);
+            document.getElementById("lacksreadme").appendChild(createRow());
         }
     }
 }
@@ -106,7 +131,7 @@ function getUser(){
     // be stalkey, because why not
     var _gaq = _gaq || [];
     _gaq.push(['users._setAccount', 'UA-58732341-2']);
-    _gaq.push(['users._trackEvent', 'userChecked', user])
+    _gaq.push(['users._trackEvent', 'userChecked', user]);
 
     var oReq = new XMLHttpRequest();
     oReq.onload = handleRepoList;
@@ -126,6 +151,18 @@ document.querySelector('#ghform').addEventListener('submit', function(ev){
     ev.preventDefault();
     getUser();
     return false;
+});
+
+document.querySelector("#hideforks").addEventListener('change', function(ev) {
+  var forkNodes = document.querySelectorAll(".fork");
+  for(var i = 0; i < forkNodes.length; i++) {
+    if (ev.target.checked) {
+      forkNodes[i].classList.add("hide-fork");
+    }
+    else {
+      forkNodes[i].classList.remove("hide-fork");
+    }
+  }
 });
 
 })();

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">    
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,11 +11,17 @@
 <body>
 <div class="importantstuff">
         <form id="ghform">
+            <label for="ghuser">Username: </label>
             <input type="text" id="ghuser"/>
+            <br>
+            <label for="ghtoken">Github API Token (<i>optional</i>): </label>
+            <input type="password" id="ghtoken"/>
+            <br>
             <button type="submit">Stalk Repos</button>
         </form>
     <div id="instructions">
         <p>Enter your GitHub username in the box above and click the button!</p>
+        <p>If you get rate limited, you can enter a token as found <a href="https://github.com/settings/tokens">here</a>.</p>
         <p>The script will look up whether your public repos have
         licenses.</p>
         <p>This page uses Google Analytics to track which usernames have been
@@ -30,7 +36,7 @@
         </div>
         <div class="rightColumn">
             <h2>Thank you for licensing:</h2>
-            <ul id=haslicense>
+            <ul id="haslicense">
             </ul>
         </div>
     </div>
@@ -43,7 +49,7 @@
         </div>
         <div class="rightColumn">
             <h2>Thank you for having a README in:</h2>
-            <ul id=hasreadme>
+            <ul id="hasreadme">
             </ul>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
             <input type="password" id="ghtoken"/>
             <br>
             <button type="submit">Stalk Repos</button>
+            <br>
+            <label for="hideforks">Hide forks?</label>
+            <input type="checkbox" checked="true" id="hideforks"/>
         </form>
     <div id="instructions">
         <p>Enter your GitHub username in the box above and click the button!</p>

--- a/style.css
+++ b/style.css
@@ -12,13 +12,14 @@ body { margin: 0; }
 
 .leftColumn { margin-bottom: .5em; }
 .rightColumn{ margin-bottom: 20em; }
-.staydown{ 
+.staydown{
         left: 0;
         right: 0;
         bottom:0;
         position:fixed;
         background-color:white;
 }
+.hide-fork { display: none; }
 /* MEDIA QUERIES */
 @media screen and (min-width: 47.5em ) {
     .leftColumn { margin-right: 19.5em; }


### PR DESCRIPTION
Someone isn't typically directly responsible for the license / readme of a fork of a project; they might be, but they can uncheck the box to see those still.

This should help with signal-to-noise ratio a little bit.

This also adds a possibly more controversial change; adding an input box for a github token (and some links to make one).
This is not as nice as having pretty oauth "login-with-github" type integration, but I see it as an easy-to-implement medium that can be ripped out once there's a cleaner implementation.

I did keep them as separate commits, so if you'd like me to rebase and nix the token change, I'd be happy to do so.
